### PR TITLE
refactor(fastf1): rename 'prediction' to 'fastf1' and update all rela…

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
-from app.routers import prediction
+from app.routers import openf1
+from app.routers import fastf1
 
 app = FastAPI(
     title="F1 Season Predictor API",
@@ -8,7 +9,8 @@ app = FastAPI(
 )
 
 # Include API routes
-app.include_router(prediction.router)
+app.include_router(fastf1.router)
+app.include_router(openf1.router)
 
 @app.get("/")
 async def root():

--- a/backend/app/routers/fastf1.py
+++ b/backend/app/routers/fastf1.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from app.services.f1_data import load_race_data, load_driver_performance, load_race_results, load_driver_standings, load_historical_data, load_qualifying_results, load_weather_data, load_driver_trends
 
-router = APIRouter(prefix="/prediction", tags=["Prediction"])
+router = APIRouter(prefix="/fastf1", tags=["FastF1"])
 
 @router.get("/historical-data/{year}")
 async def get_historical_data(year: int, driver: str = None):

--- a/backend/tests/test_fastf1.py
+++ b/backend/tests/test_fastf1.py
@@ -7,48 +7,48 @@ client = TestClient(app)
 
 # 1. Test Historical Data Endpoint
 def test_historical_data():
-    response = client.get("/prediction/historical-data/2023")
+    response = client.get("/fastf1/historical-data/2023")
     assert response.status_code == 200
     assert "error" not in response.json()  # Ensure no error in response
 
 # 2. Test Driver Standings Endpoint
 def test_driver_standings():
-    response = client.get("/prediction/standings/2023")
+    response = client.get("/fastf1/standings/2023")
     assert response.status_code == 200
     assert "standings" in response.json()
 
 # 3. Test Race Prediction Endpoint
 def test_predict_race():
-    response = client.get("/prediction/2023/Monaco")
+    response = client.get("/fastf1/2023/Monaco")
     assert response.status_code == 200
     assert "race" in response.json()
 
 # 4. Test Driver Performance Endpoint
 def test_driver_performance():
-    response = client.get("/prediction/driver-performance/2023/Monaco/VER")
+    response = client.get("/fastf1/driver-performance/2023/Monaco/VER")
     assert response.status_code == 200
     assert "driver" in response.json()
 
 # 5. Test Race Results Endpoint
 def test_race_results():
-    response = client.get("/prediction/race-results/2023/Monaco")
+    response = client.get("/fastf1/race-results/2023/Monaco")
     assert response.status_code == 200
     assert "results" in response.json()
 
 # 6. Test Qualifying Results Endpoint
 def test_qualifying_results():
-    response = client.get("/prediction/qualifying-results/2023/Monaco")
+    response = client.get("/fastf1/qualifying-results/2023/Monaco")
     assert response.status_code == 200
     assert "qualifying_results" in response.json()
 
 # 7. Test Weather Data Endpoint
 def test_weather_data():
-    response = client.get("/prediction/weather/2023/Monaco")
+    response = client.get("/fastf1/weather/2023/Monaco")
     assert response.status_code == 200
     assert "weather" in response.json()
 
 # 8. Test Driver Trends Endpoint
 def test_driver_trends():
-    response = client.get("/prediction/driver-trends/2023/VER")
+    response = client.get("/fastf1/driver-trends/2023/VER")
     assert response.status_code == 200
     assert "driver" in response.json()


### PR DESCRIPTION
…ted tests

- Renamed all routes and references from 'prediction' to 'fastf1'
- Updated associated test cases to use the new 'fastf1' naming convention
- Ensured consistency across codebase and documentation